### PR TITLE
fix(ci): switch apko example config from maven to nginx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   IMAGE_REPO: ttl.sh/test-${{ github.job }}-${{ github.run_id }}
-  APKO_CONFIG: https://raw.githubusercontent.com/chainguard-images/images/main/images/maven/config/template.apko.yaml
+  APKO_CONFIG: https://raw.githubusercontent.com/chainguard-dev/apko/refs/heads/main/examples/nginx.yaml
 
 jobs:
   ci:
@@ -33,7 +33,7 @@ jobs:
             apko publish apko.yaml "${IMAGE_REPO}" \
               --repository-append=https://packages.wolfi.dev/os \
               --keyring-append=https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
-              --package-append=wolfi-baselayout,maven,openjdk-17,openjdk-17-default-jvm \
+              --package-append=wolfi-baselayout,nginx \
               --arch=x86_64,aarch64 \
               --image-refs=apko.images.txt | tee apko.index.txt
             index_digest="$(cat apko.index.txt)"
@@ -48,7 +48,7 @@ jobs:
       - name: Make sure the image runs
         run: |
           set -x
-          docker run --rm -e JAVA_HOME=/usr/lib/jvm/java-17-openjdk "${IMAGE_REPO}:latest" --version
+          docker run --rm --entrypoint /usr/sbin/nginx "${IMAGE_REPO}:latest" -v
 
   ci-debug:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
             apko publish apko.yaml "${IMAGE_REPO}" \
               --repository-append=https://packages.wolfi.dev/os \
               --keyring-append=https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
-              --package-append=wolfi-baselayout,maven,openjdk-17,openjdk-17-default-jvm \
+              --package-append=wolfi-baselayout,nginx \
               --arch=x86_64,aarch64 \
               --image-refs=apko.images.txt | tee apko.index.txt
             index_digest="$(cat apko.index.txt)"
@@ -91,4 +91,4 @@ jobs:
       - name: Make sure the image runs
         run: |
           set -x
-          docker run --rm -e JAVA_HOME=/usr/lib/jvm/java-17-openjdk "${IMAGE_REPO}:latest" --version
+          docker run --rm --entrypoint /usr/sbin/nginx "${IMAGE_REPO}:latest" -v


### PR DESCRIPTION
The `chainguard-images/images` maven template used by the CI jobs is no longer reliably
available, causing unrelated CI failures on PRs.

Switch `APKO_CONFIG` to the nginx example from the apko repo itself
(`chainguard-dev/apko/examples/nginx.yaml`), update `--package-append` to install
`wolfi-baselayout,nginx` instead of the maven/openjdk stack, and update the smoke-test
step to run `nginx -v` instead of the java-specific invocation.

Unrelated to PSEC-923 — purely a CI maintenance fix.